### PR TITLE
Add the namespace manually on item_type class of the version

### DIFF
--- a/lib/paper_trail/reifier.rb
+++ b/lib/paper_trail/reifier.rb
@@ -125,7 +125,7 @@ module PaperTrail
         inheritance_column_name = version.item_type.constantize.inheritance_column
         inher_col_value = attrs[inheritance_column_name]
         class_name = inher_col_value.blank? ? version.item_type : inher_col_value
-        class_name.constantize
+        class_name.safe_constantize || "#{version.item_type}::#{inher_col_value}".constantize
       end
     end
   end


### PR DESCRIPTION
# Story Title

[NameError: uninitialized constant Storage. Did you mean?  Storext](https://www.pivotaltracker.com/story/show/169391076)

# Changes made

- Add manually the concatenation of the module and the item type class.

# How does the solution address the problem

Add a second option when getting the item type of the class of a version. The reason behind this is that paper_trail cannot instantiate a new `ActiveRecord` with the item_type saved in our Database. 

We have STI in `InventoryItem` and one of its children is `Storage`. The `type` column in `InventoryItem` determines what class would that be. The problem is that we are saving only the class name instead of the module + class name. So in case of the `Storage`, we are saving it to `type` column as `'Storage'` and not `'InventoryItem::Storage'`.
